### PR TITLE
fix error in the fetch method

### DIFF
--- a/reptiles-client.js
+++ b/reptiles-client.js
@@ -36,6 +36,7 @@
         if (!Object.keys(self.queue).length) return resolve(true);
         var queue = self.queue;
         self.queue = {};
+        var buffer = "";
               
         function processBuffer(text) {
           buffer += text;


### PR DESCRIPTION
since `buffer` wasn't defined initially. code was appending `undefined` to the beginning of the responses. this fixes that by defining `buffer` as an empty string.
